### PR TITLE
Add storage type parameter to CustomEnumDefinition.FromEnum

### DIFF
--- a/docs/docs/essentials/custom-properties.md
+++ b/docs/docs/essentials/custom-properties.md
@@ -138,7 +138,7 @@ The equivalent definition in DotTiled would look like the following:
 var entityTypeDefinition = new CustomEnumDefinition
 {
   Name = "EntityType",
-  StorageType = CustomEnumStorageType.Int,
+  StorageType = CustomEnumStorageType.String,
   ValueAsFlags = false,
   Values = [
     "Bomb",
@@ -149,7 +149,7 @@ var entityTypeDefinition = new CustomEnumDefinition
 };
 ```
 
-Similarly to custom class definitions, you can also automatically generate custom enum definitions from C# enums. This is done by using the <xref:DotTiled.CustomEnumDefinition.FromEnum``1> method, or one of its overloads. This method will generate a <xref:DotTiled.CustomEnumDefinition> from a given C# enum, and you can then use this definition when loading your maps.
+Similarly to custom class definitions, you can also automatically generate custom enum definitions from C# enums. This is done by using the <xref:DotTiled.CustomEnumDefinition.FromEnum``1(DotTiled.CustomEnumStorageType)> method, or one of its overloads. This method will generate a <xref:DotTiled.CustomEnumDefinition> from a given C# enum, and you can then use this definition when loading your maps.
 
 ```csharp
 enum EntityType
@@ -170,6 +170,9 @@ var entityTypeDefinition2 = CustomEnumDefinition.FromEnum(typeof(EntityType));
 The generated custom enum definition will be identical to the one defined manually in the first example.
 
 For enum definitions, the <xref:System.FlagsAttribute> can be used to indicate that the enum should be treated as a flags enum. This will make it so the enum definition will have `ValueAsFlags = true` and the enum values will be treated as flags when working with them in DotTiled.
+
+> [!NOTE]
+> Tiled supports enums which can store their values as either strings or integers, and depending on the storage type you have specified in Tiled, you must make sure to have the same storage type in your <xref:DotTiled.CustomEnumDefinition>. This can be done by setting the `StorageType` property to either `CustomEnumStorageType.String` or `CustomEnumStorageType.Int` when creating the definition, or by passing the storage type as an argument to the <xref:DotTiled.CustomEnumDefinition.FromEnum``1(DotTiled.CustomEnumStorageType)> method. To be consistent with Tiled, <xref:DotTiled.CustomEnumDefinition.FromEnum``1(DotTiled.CustomEnumStorageType)> will default to `CustomEnumStorageType.String` for the storage type parameter.
 
 ## Mapping properties to C# classes or enums
 

--- a/src/DotTiled.Tests/UnitTests/Properties/CustomTypes/CustomEnumDefinitionTests.cs
+++ b/src/DotTiled.Tests/UnitTests/Properties/CustomTypes/CustomEnumDefinitionTests.cs
@@ -14,8 +14,10 @@ public class CustomEnumDefinitionTests
 
   private enum TestEnum1 { Value1, Value2, Value3 }
 
-  [Fact]
-  public void FromEnum_Type_WhenTypeIsEnum_ReturnsCustomEnumDefinition()
+  [Theory]
+  [InlineData(CustomEnumStorageType.String)]
+  [InlineData(CustomEnumStorageType.Int)]
+  public void FromEnum_Type_WhenTypeIsEnum_ReturnsCustomEnumDefinition(CustomEnumStorageType storageType)
   {
     // Arrange
     var type = typeof(TestEnum1);
@@ -23,13 +25,13 @@ public class CustomEnumDefinitionTests
     {
       ID = 0,
       Name = "TestEnum1",
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = ["Value1", "Value2", "Value3"],
       ValueAsFlags = false
     };
 
     // Act
-    var result = CustomEnumDefinition.FromEnum(type);
+    var result = CustomEnumDefinition.FromEnum(type, storageType);
 
     // Assert
     DotTiledAssert.AssertCustomEnumDefinitionEqual(expected, result);
@@ -38,8 +40,10 @@ public class CustomEnumDefinitionTests
   [Flags]
   private enum TestEnum2 { Value1, Value2, Value3 }
 
-  [Fact]
-  public void FromEnum_Type_WhenEnumIsFlags_ReturnsCustomEnumDefinition()
+  [Theory]
+  [InlineData(CustomEnumStorageType.String)]
+  [InlineData(CustomEnumStorageType.Int)]
+  public void FromEnum_Type_WhenEnumIsFlags_ReturnsCustomEnumDefinition(CustomEnumStorageType storageType)
   {
     // Arrange
     var type = typeof(TestEnum2);
@@ -47,53 +51,57 @@ public class CustomEnumDefinitionTests
     {
       ID = 0,
       Name = "TestEnum2",
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = ["Value1", "Value2", "Value3"],
       ValueAsFlags = true
     };
 
     // Act
-    var result = CustomEnumDefinition.FromEnum(type);
+    var result = CustomEnumDefinition.FromEnum(type, storageType);
 
     // Assert
     DotTiledAssert.AssertCustomEnumDefinitionEqual(expected, result);
   }
 
-  [Fact]
-  public void FromEnum_T_WhenTypeIsEnum_ReturnsCustomEnumDefinition()
+  [Theory]
+  [InlineData(CustomEnumStorageType.String)]
+  [InlineData(CustomEnumStorageType.Int)]
+  public void FromEnum_T_WhenTypeIsEnum_ReturnsCustomEnumDefinition(CustomEnumStorageType storageType)
   {
     // Arrange
     var expected = new CustomEnumDefinition
     {
       ID = 0,
       Name = "TestEnum1",
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = ["Value1", "Value2", "Value3"],
       ValueAsFlags = false
     };
 
     // Act
-    var result = CustomEnumDefinition.FromEnum<TestEnum1>();
+    var result = CustomEnumDefinition.FromEnum<TestEnum1>(storageType);
 
     // Assert
     DotTiledAssert.AssertCustomEnumDefinitionEqual(expected, result);
   }
 
-  [Fact]
-  public void FromEnum_T_WhenEnumIsFlags_ReturnsCustomEnumDefinition()
+  [Theory]
+  [InlineData(CustomEnumStorageType.String)]
+  [InlineData(CustomEnumStorageType.Int)]
+  public void FromEnum_T_WhenEnumIsFlags_ReturnsCustomEnumDefinition(CustomEnumStorageType storageType)
   {
     // Arrange
     var expected = new CustomEnumDefinition
     {
       ID = 0,
       Name = "TestEnum2",
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = ["Value1", "Value2", "Value3"],
       ValueAsFlags = true
     };
 
     // Act
-    var result = CustomEnumDefinition.FromEnum<TestEnum2>();
+    var result = CustomEnumDefinition.FromEnum<TestEnum2>(storageType);
 
     // Assert
     DotTiledAssert.AssertCustomEnumDefinitionEqual(expected, result);

--- a/src/DotTiled/Properties/CustomTypes/CustomEnumDefinition.cs
+++ b/src/DotTiled/Properties/CustomTypes/CustomEnumDefinition.cs
@@ -51,8 +51,9 @@ public class CustomEnumDefinition : ICustomTypeDefinition
   /// Creates a custom enum definition from the specified enum type.
   /// </summary>
   /// <typeparam name="T"></typeparam>
+  /// <param name="storageType">The storage type of the custom enum. Defaults to <see cref="CustomEnumStorageType.String"/> to be consistent with Tiled.</param>
   /// <returns></returns>
-  public static CustomEnumDefinition FromEnum<T>() where T : Enum
+  public static CustomEnumDefinition FromEnum<T>(CustomEnumStorageType storageType = CustomEnumStorageType.String) where T : Enum
   {
     var type = typeof(T);
     var isFlags = type.GetCustomAttributes(typeof(FlagsAttribute), false).Length != 0;
@@ -60,7 +61,7 @@ public class CustomEnumDefinition : ICustomTypeDefinition
     return new CustomEnumDefinition
     {
       Name = type.Name,
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = Enum.GetNames(type).ToList(),
       ValueAsFlags = isFlags
     };
@@ -69,8 +70,10 @@ public class CustomEnumDefinition : ICustomTypeDefinition
   /// <summary>
   /// Creates a custom enum definition from the specified enum type.
   /// </summary>
+  /// <param name="type">The enum type to create a custom enum definition from.</param>
+  /// <param name="storageType">The storage type of the custom enum. Defaults to <see cref="CustomEnumStorageType.String"/> to be consistent with Tiled.</param>
   /// <returns></returns>
-  public static CustomEnumDefinition FromEnum(Type type)
+  public static CustomEnumDefinition FromEnum(Type type, CustomEnumStorageType storageType = CustomEnumStorageType.String)
   {
     if (!type.IsEnum)
       throw new ArgumentException("Type must be an enum.", nameof(type));
@@ -80,7 +83,7 @@ public class CustomEnumDefinition : ICustomTypeDefinition
     return new CustomEnumDefinition
     {
       Name = type.Name,
-      StorageType = CustomEnumStorageType.Int,
+      StorageType = storageType,
       Values = Enum.GetNames(type).ToList(),
       ValueAsFlags = isFlags
     };


### PR DESCRIPTION
## Description

As described in #53, it is currently not possible to use the FromEnum method to create CustomEnumDefinitions that have storage type = string. It does not make sense to constrain the use of FromEnum to enums that are integer based - so this change aims to fix that.

To be consistent with Tiled, the default value for the storage type parameter has been set to `CustomEnumStorageType.String`, even though that is a breaking change. However, since we have not had a full release (i.e. 1.0.0), this should not be a major concern, the 0.x.x development cycle is expected to contain potentially breaking changes since there hasn't been a full release yet.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).

