### PR TITLE
Remove claims about map saving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ docs-serve: docs/index.md
 docs-build: docs/index.md
 	docfx docs/docfx.json
 
-docs/index.md: 
+docs/index.md: README.md
 	cp README.md docs/index.md
 
 lint:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://www.mapeditor.org/img/tiled-logo-white.png" align="right" width="20%"/>
 
-DotTiled is a simple and easy-to-use library for loading, saving, and managing [Tiled maps and tilesets](https://mapeditor.org) in your .NET projects. After [TiledCS](https://github.com/TheBoneJarmer/TiledCS) unfortunately became unmaintained (since 2022), I aimed to create a new library that could fill its shoes. DotTiled is the result of that effort.
+DotTiled is a simple and easy-to-use library for loading [Tiled maps and tilesets](https://mapeditor.org) in your .NET projects. After [TiledCS](https://github.com/TheBoneJarmer/TiledCS) unfortunately became unmaintained (since 2022), I aimed to create a new library that could fill its shoes. DotTiled is the result of that effort.
 
 DotTiled is designed to be a lightweight and efficient library that provides a simple API for loading and managing Tiled maps and tilesets. It is built with performance in mind and aims to be as fast and memory-efficient as possible.
 

--- a/src/DotTiled/README.md
+++ b/src/DotTiled/README.md
@@ -1,6 +1,6 @@
 # 📚 DotTiled
 
-DotTiled is a simple and easy-to-use library for loading, saving, and managing [Tiled maps and tilesets](https://mapeditor.org) in your .NET projects. After [TiledCS](https://github.com/TheBoneJarmer/TiledCS) unfortunately became unmaintained (since 2022), I aimed to create a new library that could fill its shoes. DotTiled is the result of that effort.
+DotTiled is a simple and easy-to-use library for loading [Tiled maps and tilesets](https://mapeditor.org) in your .NET projects. After [TiledCS](https://github.com/TheBoneJarmer/TiledCS) unfortunately became unmaintained (since 2022), I aimed to create a new library that could fill its shoes. DotTiled is the result of that effort.
 
 DotTiled is designed to be a lightweight and efficient library that provides a simple API for loading and managing Tiled maps and tilesets. It is built with performance in mind and aims to be as fast and memory-efficient as possible.
 


### PR DESCRIPTION
## Description

There were confusing claims about being able to save Tiled maps to files in the README's in various places. As that functionality does not exist and is not yet planned, those claims have been removed.

Related to #51

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
