### PR TITLE
Add flipping flags parsing/clearing to tile objects

### DIFF
--- a/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.cs
@@ -20,8 +20,8 @@ public partial class TestData
     BackgroundColor = Color.Parse("#00000000", CultureInfo.InvariantCulture),
     Version = "1.10",
     TiledVersion = "1.11.0",
-    NextLayerID = 2,
-    NextObjectID = 1,
+    NextLayerID = 3,
+    NextObjectID = 3,
     Tilesets = [
       new Tileset
       {
@@ -68,6 +68,33 @@ public partial class TestData
             FlippingFlags.FlippedHorizontally, FlippingFlags.FlippedHorizontally, FlippingFlags.FlippedHorizontally, FlippingFlags.FlippedHorizontally, FlippingFlags.None
           ])
         }
+      },
+      new ObjectLayer
+      {
+        ID = 2,
+        Name = "Object Layer 1",
+        Objects = [
+          new TileObject
+          {
+            ID = 1,
+            GID = 21,
+            X = 80.0555f,
+            Y = 48.3887f,
+            Width = 32,
+            Height = 32,
+            FlippingFlags = FlippingFlags.FlippedHorizontally
+          },
+          new TileObject
+          {
+            ID = 2,
+            GID = 21,
+            X = 15.833f,
+            Y = 112.056f,
+            Width = 32,
+            Height = 32,
+            FlippingFlags = FlippingFlags.FlippedHorizontally | FlippingFlags.FlippedVertically
+          }
+        ]
       }
     ]
   };

--- a/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.tmj
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.tmj
@@ -17,9 +17,44 @@
          "width":5,
          "x":0,
          "y":0
+        }, 
+        {
+         "draworder":"topdown",
+         "id":2,
+         "name":"Object Layer 1",
+         "objects":[
+                {
+                 "gid":2147483669,
+                 "height":32,
+                 "id":1,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":32,
+                 "x":80.0555234239445,
+                 "y":48.3886639676113
+                }, 
+                {
+                 "gid":1073741845,
+                 "height":32,
+                 "id":2,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":32,
+                 "x":15.8334297281666,
+                 "y":112.055523423944
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "x":0,
+         "y":0
         }],
- "nextlayerid":2,
- "nextobjectid":1,
+ "nextlayerid":3,
+ "nextobjectid":3,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.0",

--- a/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.tmx
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-flippingflags/map-with-flippingflags.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="3" nextobjectid="3">
  <tileset firstgid="1" source="tileset.tsx"/>
  <layer id="1" name="Tile Layer 1" width="5" height="5">
   <data encoding="csv">
@@ -10,4 +10,8 @@
 2147483669,2147483669,2147483669,2147483669,1
 </data>
  </layer>
+ <objectgroup id="2" name="Object Layer 1">
+  <object id="1" gid="2147483669" x="80.0555" y="48.3887" width="32" height="32"/>
+  <object id="2" gid="1073741845" x="15.8334" y="112.056" width="32" height="32"/>
+ </objectgroup>
 </map>

--- a/src/DotTiled/Layers/Objects/TileObject.cs
+++ b/src/DotTiled/Layers/Objects/TileObject.cs
@@ -9,4 +9,9 @@ public class TileObject : Object
   /// A reference to a tile.
   /// </summary>
   public uint GID { get; set; }
+
+  /// <summary>
+  /// The flipping flags for the tile.
+  /// </summary>
+  public FlippingFlags FlippingFlags { get; set; }
 }

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using System.Text.Json;
 
@@ -117,6 +118,8 @@ public abstract partial class TmjReaderBase
 
     if (gid.HasValue)
     {
+      var (clearedGIDs, flippingFlags) = Helpers.ReadAndClearFlippingFlagsFromGIDs([gid.Value]);
+
       return new TileObject
       {
         ID = id,
@@ -130,7 +133,8 @@ public abstract partial class TmjReaderBase
         Visible = visible,
         Template = template,
         Properties = properties,
-        GID = gid.Value
+        GID = clearedGIDs.Single(),
+        FlippingFlags = flippingFlags.Single()
       };
     }
 

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
@@ -118,9 +118,14 @@ public abstract partial class TmxReaderBase
     if (foundObject is null)
     {
       if (gid.HasValue)
-        foundObject = new TileObject { ID = id, GID = gid.Value };
+      {
+        var (clearedGIDs, flippingFlags) = Helpers.ReadAndClearFlippingFlagsFromGIDs([gid.Value]);
+        foundObject = new TileObject { ID = id, GID = clearedGIDs.Single(), FlippingFlags = flippingFlags.Single() };
+      }
       else
+      {
         foundObject = new RectangleObject { ID = id };
+      }
     }
 
     foundObject.ID = id;


### PR DESCRIPTION
## Description

As described in #43, Flipping Flags are not properly parsed and cleared from global tile IDs for tile objects. This would mean that a user would have to perform their own clearing of flipping flags to get a useful GID. As this is handled properly when parsing other tile data, it should be performed here too to not cause confusion.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).

