### PR TITLE
Fix multiline string property value parsing

### DIFF
--- a/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.cs
@@ -1,0 +1,65 @@
+using System.Globalization;
+
+namespace DotTiled.Tests;
+
+public partial class TestData
+{
+  public static Map MapWithMultilineStringProp() => new Map
+  {
+    Class = "",
+    Orientation = MapOrientation.Isometric,
+    Width = 5,
+    Height = 5,
+    TileWidth = 32,
+    TileHeight = 16,
+    Infinite = false,
+    ParallaxOriginX = 0,
+    ParallaxOriginY = 0,
+    RenderOrder = RenderOrder.RightDown,
+    CompressionLevel = -1,
+    BackgroundColor = Color.Parse("#00ff00", CultureInfo.InvariantCulture),
+    Version = "1.10",
+    TiledVersion = "1.11.0",
+    NextLayerID = 2,
+    NextObjectID = 1,
+    Layers = [
+      new TileLayer
+      {
+        ID = 1,
+        Name = "Tile Layer 1",
+        Width = 5,
+        Height = 5,
+        Data = new Data
+        {
+          Encoding = DataEncoding.Csv,
+          GlobalTileIDs = new Optional<uint[]>([
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0
+          ]),
+          FlippingFlags = new Optional<FlippingFlags[]>([
+            FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None,
+            FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None,
+            FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None,
+            FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None,
+            FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None, FlippingFlags.None
+          ])
+        }
+      }
+    ],
+    Properties =
+    [
+      new BoolProperty { Name = "boolprop", Value = true },
+      new ColorProperty { Name = "colorprop", Value = Color.Parse("#ff55ffff", CultureInfo.InvariantCulture) },
+      new FileProperty { Name = "fileprop", Value = "file.txt" },
+      new FloatProperty { Name = "floatprop", Value = 4.2f },
+      new IntProperty { Name = "intprop", Value = 8 },
+      new ObjectProperty { Name = "objectprop", Value = 5 },
+      new StringProperty { Name = "stringmultiline", Value = "hello there\n\ni am a multiline\nstring property" },
+      new StringProperty { Name = "stringprop", Value = "This is a string, hello world!" },
+      new StringProperty { Name = "unsetstringprop", Value = "" }
+    ]
+  };
+}

--- a/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.tmj
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.tmj
@@ -1,0 +1,80 @@
+{ "backgroundcolor":"#00ff00",
+ "compressionlevel":-1,
+ "height":5,
+ "infinite":false,
+ "layers":[
+        {
+         "data":[0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0],
+         "height":5,
+         "id":1,
+         "name":"Tile Layer 1",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":5,
+         "x":0,
+         "y":0
+        }],
+ "nextlayerid":2,
+ "nextobjectid":1,
+ "orientation":"isometric",
+ "properties":[
+        {
+         "name":"boolprop",
+         "type":"bool",
+         "value":true
+        }, 
+        {
+         "name":"colorprop",
+         "type":"color",
+         "value":"#ff55ffff"
+        }, 
+        {
+         "name":"fileprop",
+         "type":"file",
+         "value":"file.txt"
+        }, 
+        {
+         "name":"floatprop",
+         "type":"float",
+         "value":4.2
+        }, 
+        {
+         "name":"intprop",
+         "type":"int",
+         "value":8
+        },
+    
+        {
+         "name":"objectprop",
+         "type":"object",
+         "value":5
+        }, 
+        {
+         "name":"stringmultiline",
+         "type":"string",
+         "value":"hello there\n\ni am a multiline\nstring property"
+        }, 
+        {
+         "name":"stringprop",
+         "type":"string",
+         "value":"This is a string, hello world!"
+        }, 
+        {
+         "name":"unsetstringprop",
+         "type":"string",
+         "value":""
+        }],
+ "renderorder":"right-down",
+ "tiledversion":"1.11.0",
+ "tileheight":16,
+ "tilesets":[],
+ "tilewidth":32,
+ "type":"map",
+ "version":"1.10",
+ "width":5
+}

--- a/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.tmx
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-multiline-string-prop/map-with-multiline-string-prop.tmx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" tiledversion="1.11.0" orientation="isometric" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="16" infinite="0" backgroundcolor="#00ff00" nextlayerid="2" nextobjectid="1">
+ <properties>
+  <property name="boolprop" type="bool" value="true"/>
+  <property name="colorprop" type="color" value="#ff55ffff"/>
+  <property name="fileprop" type="file" value="file.txt"/>
+  <property name="floatprop" type="float" value="4.2"/>
+  <property name="intprop" type="int" value="8"/>
+  <property name="objectprop" type="object" value="5"/>
+  <property name="stringmultiline">hello there
+
+i am a multiline
+string property</property>
+  <property name="stringprop" value="This is a string, hello world!"/>
+  <property name="unsetstringprop" value=""/>
+ </properties>
+ <layer id="1" name="Tile Layer 1" width="5" height="5">
+  <data encoding="csv">
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0
+</data>
+ </layer>
+</map>

--- a/src/DotTiled.Tests/UnitTests/Serialization/TestData.cs
+++ b/src/DotTiled.Tests/UnitTests/Serialization/TestData.cs
@@ -42,6 +42,7 @@ public static partial class TestData
     [GetMapPath("map-external-tileset-multi"), (string f) => MapExternalTilesetMulti(f), Array.Empty<ICustomTypeDefinition>()],
     [GetMapPath("map-external-tileset-wangset"), (string f) => MapExternalTilesetWangset(f), Array.Empty<ICustomTypeDefinition>()],
     [GetMapPath("map-with-many-layers"), (string f) => MapWithManyLayers(f), Array.Empty<ICustomTypeDefinition>()],
+    [GetMapPath("map-with-multiline-string-prop"), (string f) => MapWithMultilineStringProp(), Array.Empty<ICustomTypeDefinition>()],
     [GetMapPath("map-with-deep-props"), (string f) => MapWithDeepProps(), MapWithDeepPropsCustomTypeDefinitions()],
     [GetMapPath("map-with-class"), (string f) => MapWithClass(), MapWithClassCustomTypeDefinitions()],
     [GetMapPath("map-with-class-and-props"), (string f) => MapWithClassAndProps(), MapWithClassAndPropsCustomTypeDefinitions()],


### PR DESCRIPTION
## Description

All string properties for the `.tmx` file format expected the string value to exist in the `value` attribute. However, for multiline string properties, the string value will be placed inbetween the property tags (body). This is addressed in this PR so that we properly parse multiline string properties without causing a crash.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).

