### PR TITLE
Unset colors are now parsed correctly, color properties have optional colors

### DIFF
--- a/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.cs
@@ -57,7 +57,8 @@ public partial class TestData
       new FloatProperty { Name = "floatprop", Value = 4.2f },
       new IntProperty { Name = "intprop", Value = 8 },
       new ObjectProperty { Name = "objectprop", Value = 5 },
-      new StringProperty { Name = "stringprop", Value = "This is a string, hello world!" }
+      new StringProperty { Name = "stringprop", Value = "This is a string, hello world!" },
+      new ColorProperty { Name = "unsetcolorprop", Value = Optional<Color>.Empty }
     ]
   };
 }

--- a/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.tmj
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.tmj
@@ -58,6 +58,11 @@
          "name":"stringprop",
          "type":"string",
          "value":"This is a string, hello world!"
+        }, 
+        {
+         "name":"unsetcolorprop",
+         "type":"color",
+         "value":""
         }],
  "renderorder":"right-down",
  "tiledversion":"1.11.0",

--- a/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.tmx
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-common-props/map-with-common-props.tmx
@@ -8,6 +8,7 @@
   <property name="intprop" type="int" value="8"/>
   <property name="objectprop" type="object" value="5"/>
   <property name="stringprop" value="This is a string, hello world!"/>
+  <property name="unsetcolorprop" type="color" value=""/>
  </properties>
  <layer id="1" name="Tile Layer 1" width="5" height="5">
   <data encoding="csv">

--- a/src/DotTiled/Properties/ColorProperty.cs
+++ b/src/DotTiled/Properties/ColorProperty.cs
@@ -3,7 +3,7 @@ namespace DotTiled;
 /// <summary>
 /// Represents a color property.
 /// </summary>
-public class ColorProperty : IProperty<Color>
+public class ColorProperty : IProperty<Optional<Color>>
 {
   /// <inheritdoc/>
   public required string Name { get; set; }
@@ -14,7 +14,7 @@ public class ColorProperty : IProperty<Color>
   /// <summary>
   /// The color value of the property.
   /// </summary>
-  public required Color Value { get; set; }
+  public required Optional<Color> Value { get; set; }
 
   /// <inheritdoc/>
   public IProperty Clone() => new ColorProperty

--- a/src/DotTiled/Properties/IHasProperties.cs
+++ b/src/DotTiled/Properties/IHasProperties.cs
@@ -105,7 +105,9 @@ public abstract class HasPropertiesBase : IHasProperties
           type.GetProperty(prop.Name)?.SetValue(instance, boolProp.Value);
           break;
         case ColorProperty colorProp:
-          type.GetProperty(prop.Name)?.SetValue(instance, colorProp.Value);
+          if (!colorProp.Value.HasValue)
+            break;
+          type.GetProperty(prop.Name)?.SetValue(instance, colorProp.Value.Value);
           break;
         case FloatProperty floatProp:
           type.GetProperty(prop.Name)?.SetValue(instance, floatProp.Value);

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.Properties.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.Properties.cs
@@ -36,7 +36,7 @@ public abstract partial class TmjReaderBase
         PropertyType.Int => new IntProperty { Name = name, Value = e.GetRequiredProperty<int>("value") },
         PropertyType.Float => new FloatProperty { Name = name, Value = e.GetRequiredProperty<float>("value") },
         PropertyType.Bool => new BoolProperty { Name = name, Value = e.GetRequiredProperty<bool>("value") },
-        PropertyType.Color => new ColorProperty { Name = name, Value = e.GetRequiredPropertyParseable<Color>("value") },
+        PropertyType.Color => new ColorProperty { Name = name, Value = e.GetRequiredPropertyParseable<Color>("value", s => s == "" ? default : Color.Parse(s, CultureInfo.InvariantCulture)) },
         PropertyType.File => new FileProperty { Name = name, Value = e.GetRequiredProperty<string>("value") },
         PropertyType.Object => new ObjectProperty { Name = name, Value = e.GetRequiredProperty<uint>("value") },
         PropertyType.Class => throw new JsonException("Class property must have a property type"),

--- a/src/DotTiled/Serialization/Tmx/ExtensionsXmlReader.cs
+++ b/src/DotTiled/Serialization/Tmx/ExtensionsXmlReader.cs
@@ -45,7 +45,7 @@ internal static class ExtensionsXmlReader
     return T.Parse(value, CultureInfo.InvariantCulture);
   }
 
-  internal static Optional<T> GetOptionalAttributeParseable<T>(this XmlReader reader, string attribute, Func<string, T> parser) where T : struct
+  internal static Optional<T> GetOptionalAttributeParseable<T>(this XmlReader reader, string attribute, Func<string, T> parser)
   {
     var value = reader.GetAttribute(attribute);
     if (value is null)

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.Properties.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.Properties.cs
@@ -45,7 +45,7 @@ public abstract partial class TmxReaderBase
         PropertyType.Int => new IntProperty { Name = name, Value = r.GetRequiredAttributeParseable<int>("value") },
         PropertyType.Float => new FloatProperty { Name = name, Value = r.GetRequiredAttributeParseable<float>("value") },
         PropertyType.Bool => new BoolProperty { Name = name, Value = r.GetRequiredAttributeParseable<bool>("value") },
-        PropertyType.Color => new ColorProperty { Name = name, Value = r.GetRequiredAttributeParseable<Color>("value") },
+        PropertyType.Color => new ColorProperty { Name = name, Value = r.GetRequiredAttributeParseable<Color>("value", s => s == "" ? default : Color.Parse(s, CultureInfo.InvariantCulture)) },
         PropertyType.File => new FileProperty { Name = name, Value = r.GetRequiredAttribute("value") },
         PropertyType.Object => new ObjectProperty { Name = name, Value = r.GetRequiredAttributeParseable<uint>("value") },
         PropertyType.Class => throw new XmlException("Class property must have a property type"),


### PR DESCRIPTION
## Description

Color properties can have unset colors, so color properties should have optional values.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).

