### PR TITLE
Add ZStd Support

### DIFF
--- a/src/DotTiled/DotTiled.csproj
+++ b/src/DotTiled/DotTiled.csproj
@@ -26,4 +26,8 @@
     <None Include="../../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.5" />
+  </ItemGroup>
+
 </Project>

--- a/src/DotTiled/Serialization/Helpers.cs
+++ b/src/DotTiled/Serialization/Helpers.cs
@@ -46,6 +46,12 @@ internal static partial class Helpers
     return ReadMemoryStreamAsInt32Array(decompressedStream);
   }
 
+  internal static uint[] DecompressZStd(MemoryStream stream)
+  {
+    using var decompressedStream = new ZstdSharp.DecompressionStream(stream);
+    return ReadMemoryStreamAsInt32Array(decompressedStream);
+  }
+
   internal static uint[] ReadBytesAsInt32Array(byte[] bytes)
   {
     var intArray = new uint[bytes.Length / 4];

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.Data.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.Data.cs
@@ -78,7 +78,7 @@ public abstract partial class TmxReaderBase
     {
       DataCompression.GZip => DecompressGZip(bytes),
       DataCompression.ZLib => DecompressZLib(bytes),
-      DataCompression.ZStd => throw new NotSupportedException("ZStd compression is not supported."),
+      DataCompression.ZStd => DecompressZStd(bytes),
       _ => throw new XmlException("Invalid compression")
     };
 
@@ -115,6 +115,12 @@ public abstract partial class TmxReaderBase
   internal static uint[] DecompressZLib(MemoryStream stream)
   {
     using var decompressedStream = new ZLibStream(stream, CompressionMode.Decompress);
+    return ReadMemoryStreamAsInt32Array(decompressedStream);
+  }
+
+  internal static uint[] DecompressZStd(MemoryStream stream)
+  {
+    using var decompressedStream = new ZstdSharp.DecompressionStream(stream);
     return ReadMemoryStreamAsInt32Array(decompressedStream);
   }
 }


### PR DESCRIPTION
Adds support for ZStd using [ZstdSharp](https://github.com/oleg-st/ZstdSharp), which is a port of the [zstd compression library](https://github.com/facebook/zstd) to С#.