### PR TITLE
Use signed integers instead of unsigned

### DIFF
--- a/src/DotTiled.Tests/TestData/Maps/map-override-object-bug/map-override-object-bug.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-override-object-bug/map-override-object-bug.cs
@@ -181,8 +181,8 @@ public partial class TestData
             {
               Format = ImageFormat.Png,
               Source = "tileset.png",
-              Width = fileExt == "tmx" ? 256u : 0, // Currently, json format does not
-              Height = fileExt == "tmx" ? 96u : 0  // include image dimensions in image layer https://github.com/mapeditor/tiled/issues/4028
+              Width = fileExt == "tmx" ? 256 : 0, // Currently, json format does not
+              Height = fileExt == "tmx" ? 96 : 0  // include image dimensions in image layer https://github.com/mapeditor/tiled/issues/4028
             },
             RepeatX = true
           },

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
@@ -172,8 +172,8 @@ public partial class TestData
             {
               Format = ImageFormat.Png,
               Source = "tileset.png",
-              Width = fileExt == "tmx" ? 256u : 0, // Currently, json format does not
-              Height = fileExt == "tmx" ? 96u : 0  // include image dimensions in image layer https://github.com/mapeditor/tiled/issues/4028
+              Width = fileExt == "tmx" ? 256 : 0, // Currently, json format does not
+              Height = fileExt == "tmx" ? 96 : 0  // include image dimensions in image layer https://github.com/mapeditor/tiled/issues/4028
             },
             RepeatX = true
           },

--- a/src/DotTiled/Layers/Data.cs
+++ b/src/DotTiled/Layers/Data.cs
@@ -90,12 +90,12 @@ public class Chunk
   /// <summary>
   /// The width of the chunk in tiles.
   /// </summary>
-  public required uint Width { get; set; }
+  public required int Width { get; set; }
 
   /// <summary>
   /// The height of the chunk in tiles.
   /// </summary>
-  public required uint Height { get; set; }
+  public required int Height { get; set; }
 
   /// <summary>
   /// The parsed chunk data, as a list of tile GIDs.

--- a/src/DotTiled/Layers/ImageLayer.cs
+++ b/src/DotTiled/Layers/ImageLayer.cs
@@ -8,12 +8,12 @@ public class ImageLayer : BaseLayer
   /// <summary>
   /// The X position of the image layer in pixels.
   /// </summary>
-  public uint X { get; set; } = 0;
+  public int X { get; set; } = 0;
 
   /// <summary>
   /// The Y position of the image layer in pixels.
   /// </summary>
-  public Optional<uint> Y { get; set; } = 0;
+  public int Y { get; set; } = 0;
 
   /// <summary>
   /// Whether the image drawn by this layer is repeated along the X axis.

--- a/src/DotTiled/Layers/ObjectLayer.cs
+++ b/src/DotTiled/Layers/ObjectLayer.cs
@@ -26,22 +26,22 @@ public class ObjectLayer : BaseLayer
   /// <summary>
   /// The X coordinate of the object layer in tiles.
   /// </summary>
-  public uint X { get; set; } = 0;
+  public int X { get; set; } = 0;
 
   /// <summary>
   /// The Y coordinate of the object layer in tiles.
   /// </summary>
-  public uint Y { get; set; } = 0;
+  public int Y { get; set; } = 0;
 
   /// <summary>
   /// The width of the object layer in tiles. Meaningless.
   /// </summary>
-  public uint Width { get; set; } = 0;
+  public int Width { get; set; } = 0;
 
   /// <summary>
   /// The height of the object layer in tiles. Meaningless.
   /// </summary>
-  public uint Height { get; set; } = 0;
+  public int Height { get; set; } = 0;
 
   /// <summary>
   /// A color that is multiplied with any tile objects drawn by this layer.

--- a/src/DotTiled/Layers/TileLayer.cs
+++ b/src/DotTiled/Layers/TileLayer.cs
@@ -8,22 +8,22 @@ public class TileLayer : BaseLayer
   /// <summary>
   /// The X coordinate of the layer in tiles.
   /// </summary>
-  public uint X { get; set; } = 0;
+  public int X { get; set; } = 0;
 
   /// <summary>
   /// The Y coordinate of the layer in tiles.
   /// </summary>
-  public uint Y { get; set; } = 0;
+  public int Y { get; set; } = 0;
 
   /// <summary>
   /// The width of the layer in tiles. Always the same as the map width for fixed-size maps.
   /// </summary>
-  public required uint Width { get; set; }
+  public required int Width { get; set; }
 
   /// <summary>
   /// The height of the layer in tiles. Always the same as the map height for fixed-size maps.
   /// </summary>
-  public required uint Height { get; set; }
+  public required int Height { get; set; }
 
   /// <summary>
   /// The tile layer data.

--- a/src/DotTiled/Map.cs
+++ b/src/DotTiled/Map.cs
@@ -126,27 +126,27 @@ public class Map : HasPropertiesBase
   /// <summary>
   /// The width of the map in tiles.
   /// </summary>
-  public required uint Width { get; set; }
+  public required int Width { get; set; }
 
   /// <summary>
   /// The height of the map in tiles.
   /// </summary>
-  public required uint Height { get; set; }
+  public required int Height { get; set; }
 
   /// <summary>
   /// The width of a tile.
   /// </summary>
-  public required uint TileWidth { get; set; }
+  public required int TileWidth { get; set; }
 
   /// <summary>
   /// The height of a tile.
   /// </summary>
-  public required uint TileHeight { get; set; }
+  public required int TileHeight { get; set; }
 
   /// <summary>
   /// Only for hexagonal maps. Determines the width or height (depending on the staggered axis) of the tile's edge, in pixels.
   /// </summary>
-  public Optional<uint> HexSideLength { get; set; } = Optional<uint>.Empty;
+  public Optional<int> HexSideLength { get; set; } = Optional<int>.Empty;
 
   /// <summary>
   /// For staggered and hexagonal maps, determines which axis (X or Y) is staggered.

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.Data.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.Data.cs
@@ -23,8 +23,8 @@ public abstract partial class TmjReaderBase
 
     var x = element.GetRequiredProperty<int>("x");
     var y = element.GetRequiredProperty<int>("y");
-    var width = element.GetRequiredProperty<uint>("width");
-    var height = element.GetRequiredProperty<uint>("height");
+    var width = element.GetRequiredProperty<int>("width");
+    var height = element.GetRequiredProperty<int>("height");
 
     return new Chunk
     {

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.ImageLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.ImageLayer.cs
@@ -22,8 +22,8 @@ public abstract partial class TmjReaderBase
     var repeatX = element.GetOptionalProperty<bool>("repeatx").GetValueOr(false);
     var repeatY = element.GetOptionalProperty<bool>("repeaty").GetValueOr(false);
     var transparentColor = element.GetOptionalPropertyParseable<Color>("transparentcolor");
-    var x = element.GetOptionalProperty<uint>("x").GetValueOr(0);
-    var y = element.GetOptionalProperty<uint>("y").GetValueOr(0);
+    var x = element.GetOptionalProperty<int>("x").GetValueOr(0);
+    var y = element.GetOptionalProperty<int>("y").GetValueOr(0);
 
     var imgModel = new Image
     {

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.Map.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.Map.cs
@@ -28,11 +28,11 @@ public abstract partial class TmjReaderBase
       _ => throw new JsonException($"Unknown render order '{s}'")
     }).GetValueOr(RenderOrder.RightDown);
     var compressionLevel = element.GetOptionalProperty<int>("compressionlevel").GetValueOr(-1);
-    var width = element.GetRequiredProperty<uint>("width");
-    var height = element.GetRequiredProperty<uint>("height");
-    var tileWidth = element.GetRequiredProperty<uint>("tilewidth");
-    var tileHeight = element.GetRequiredProperty<uint>("tileheight");
-    var hexSideLength = element.GetOptionalProperty<uint>("hexsidelength");
+    var width = element.GetRequiredProperty<int>("width");
+    var height = element.GetRequiredProperty<int>("height");
+    var tileWidth = element.GetRequiredProperty<int>("tilewidth");
+    var tileHeight = element.GetRequiredProperty<int>("tileheight");
+    var hexSideLength = element.GetOptionalProperty<int>("hexsidelength");
     var staggerAxis = element.GetOptionalPropertyParseable<StaggerAxis>("staggeraxis", s => s switch
     {
       "x" => StaggerAxis.X,

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
@@ -22,10 +22,10 @@ public abstract partial class TmjReaderBase
     var parallaxY = element.GetOptionalProperty<float>("parallaxy").GetValueOr(1.0f);
     var properties = ResolveAndMergeProperties(@class, element.GetOptionalPropertyCustom("properties", ReadProperties).GetValueOr([]));
 
-    var x = element.GetOptionalProperty<uint>("x").GetValueOr(0);
-    var y = element.GetOptionalProperty<uint>("y").GetValueOr(0);
-    var width = element.GetOptionalProperty<uint>("width").GetValueOr(0);
-    var height = element.GetOptionalProperty<uint>("height").GetValueOr(0);
+    var x = element.GetOptionalProperty<int>("x").GetValueOr(0);
+    var y = element.GetOptionalProperty<int>("y").GetValueOr(0);
+    var width = element.GetOptionalProperty<int>("width").GetValueOr(0);
+    var height = element.GetOptionalProperty<int>("height").GetValueOr(0);
     var color = element.GetOptionalPropertyParseable<Color>("color");
     var drawOrder = element.GetOptionalPropertyParseable<DrawOrder>("draworder", s => s switch
     {

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.TileLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.TileLayer.cs
@@ -22,7 +22,7 @@ public abstract partial class TmjReaderBase
     var chunks = element.GetOptionalPropertyCustom<Data>("chunks", e => ReadDataAsChunks(e, compression, encoding));
     var @class = element.GetOptionalProperty<string>("class").GetValueOr("");
     var data = element.GetOptionalPropertyCustom<Data>("data", e => ReadDataWithoutChunks(e, compression, encoding));
-    var height = element.GetRequiredProperty<uint>("height");
+    var height = element.GetRequiredProperty<int>("height");
     var id = element.GetRequiredProperty<uint>("id");
     var name = element.GetRequiredProperty<string>("name");
     var offsetX = element.GetOptionalProperty<float>("offsetx").GetValueOr(0.0f);
@@ -38,9 +38,9 @@ public abstract partial class TmjReaderBase
     var tintColor = element.GetOptionalPropertyParseable<Color>("tintcolor");
     var transparentColor = element.GetOptionalPropertyParseable<Color>("transparentcolor");
     var visible = element.GetOptionalProperty<bool>("visible").GetValueOr(true);
-    var width = element.GetRequiredProperty<uint>("width");
-    var x = element.GetRequiredProperty<uint>("x");
-    var y = element.GetRequiredProperty<uint>("y");
+    var width = element.GetRequiredProperty<int>("width");
+    var x = element.GetRequiredProperty<int>("x");
+    var y = element.GetRequiredProperty<int>("y");
 
     if (!data.HasValue && !chunks.HasValue)
       throw new JsonException("Tile layer does not contain data.");

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.Tileset.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.Tileset.cs
@@ -12,7 +12,7 @@ public abstract partial class TmjReaderBase
   {
     var backgroundColor = element.GetOptionalPropertyParseable<Color>("backgroundcolor");
     var @class = element.GetOptionalProperty<string>("class").GetValueOr("");
-    var columns = element.GetOptionalProperty<uint>("columns");
+    var columns = element.GetOptionalProperty<int>("columns");
     var fillMode = element.GetOptionalPropertyParseable<FillMode>("fillmode", s => s switch
     {
       "stretch" => FillMode.Stretch,
@@ -22,9 +22,9 @@ public abstract partial class TmjReaderBase
     var firstGID = element.GetOptionalProperty<uint>("firstgid");
     var grid = element.GetOptionalPropertyCustom<Grid>("grid", ReadGrid);
     var image = element.GetOptionalProperty<string>("image");
-    var imageHeight = element.GetOptionalProperty<uint>("imageheight");
-    var imageWidth = element.GetOptionalProperty<uint>("imagewidth");
-    var margin = element.GetOptionalProperty<uint>("margin");
+    var imageHeight = element.GetOptionalProperty<int>("imageheight");
+    var imageWidth = element.GetOptionalProperty<int>("imagewidth");
+    var margin = element.GetOptionalProperty<int>("margin");
     var name = element.GetOptionalProperty<string>("name");
     var objectAlignment = element.GetOptionalPropertyParseable<ObjectAlignment>("objectalignment", s => s switch
     {
@@ -42,10 +42,10 @@ public abstract partial class TmjReaderBase
     }).GetValueOr(ObjectAlignment.Unspecified);
     var properties = ResolveAndMergeProperties(@class, element.GetOptionalPropertyCustom("properties", ReadProperties).GetValueOr([]));
     var source = element.GetOptionalProperty<string>("source");
-    var spacing = element.GetOptionalProperty<uint>("spacing");
-    var tileCount = element.GetOptionalProperty<uint>("tilecount");
+    var spacing = element.GetOptionalProperty<int>("spacing");
+    var tileCount = element.GetOptionalProperty<int>("tilecount");
     var tiledVersion = element.GetOptionalProperty<string>("tiledversion").GetValueOrOptional(parentTiledVersion);
-    var tileHeight = element.GetOptionalProperty<uint>("tileheight");
+    var tileHeight = element.GetOptionalProperty<int>("tileheight");
     var tileOffset = element.GetOptionalPropertyCustom<TileOffset>("tileoffset", ReadTileOffset);
     var tileRenderSize = element.GetOptionalPropertyParseable<TileRenderSize>("tilerendersize", s => s switch
     {
@@ -54,7 +54,7 @@ public abstract partial class TmjReaderBase
       _ => throw new JsonException($"Unknown tile render size '{s}'")
     }).GetValueOr(TileRenderSize.Tile);
     var tiles = element.GetOptionalPropertyCustom<List<Tile>>("tiles", ReadTiles).GetValueOr([]);
-    var tileWidth = element.GetOptionalProperty<uint>("tilewidth");
+    var tileWidth = element.GetOptionalProperty<int>("tilewidth");
     var transparentColor = element.GetOptionalPropertyParseable<Color>("transparentcolor");
     var type = element.GetOptionalProperty<string>("type");
     var version = element.GetOptionalProperty<string>("version").GetValueOrOptional(parentVersion);
@@ -129,8 +129,8 @@ public abstract partial class TmjReaderBase
       "isometric" => GridOrientation.Isometric,
       _ => throw new JsonException($"Unknown grid orientation '{s}'")
     }).GetValueOr(GridOrientation.Orthogonal);
-    var height = element.GetRequiredProperty<uint>("height");
-    var width = element.GetRequiredProperty<uint>("width");
+    var height = element.GetRequiredProperty<int>("height");
+    var width = element.GetRequiredProperty<int>("width");
 
     return new Grid
     {
@@ -158,12 +158,12 @@ public abstract partial class TmjReaderBase
       var animation = e.GetOptionalPropertyCustom<List<Frame>>("animation", e => e.GetValueAsList<Frame>(ReadFrame)).GetValueOr([]);
       var id = e.GetRequiredProperty<uint>("id");
       var image = e.GetOptionalProperty<string>("image");
-      var imageHeight = e.GetOptionalProperty<uint>("imageheight");
-      var imageWidth = e.GetOptionalProperty<uint>("imagewidth");
-      var x = e.GetOptionalProperty<uint>("x").GetValueOr(0);
-      var y = e.GetOptionalProperty<uint>("y").GetValueOr(0);
-      var width = e.GetOptionalProperty<uint>("width").GetValueOr(imageWidth.GetValueOr(0));
-      var height = e.GetOptionalProperty<uint>("height").GetValueOr(imageHeight.GetValueOr(0));
+      var imageHeight = e.GetOptionalProperty<int>("imageheight");
+      var imageWidth = e.GetOptionalProperty<int>("imagewidth");
+      var x = e.GetOptionalProperty<int>("x").GetValueOr(0);
+      var y = e.GetOptionalProperty<int>("y").GetValueOr(0);
+      var width = e.GetOptionalProperty<int>("width").GetValueOr(imageWidth.GetValueOr(0));
+      var height = e.GetOptionalProperty<int>("height").GetValueOr(imageHeight.GetValueOr(0));
       var objectGroup = e.GetOptionalPropertyCustom<ObjectLayer>("objectgroup", e => ReadObjectLayer(e));
       var probability = e.GetOptionalProperty<float>("probability").GetValueOr(0.0f);
       var type = e.GetOptionalProperty<string>("type").GetValueOr("");
@@ -195,7 +195,7 @@ public abstract partial class TmjReaderBase
 
   internal static Frame ReadFrame(JsonElement element)
   {
-    var duration = element.GetRequiredProperty<uint>("duration");
+    var duration = element.GetRequiredProperty<int>("duration");
     var tileID = element.GetRequiredProperty<uint>("tileid");
 
     return new Frame

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.Chunk.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.Chunk.cs
@@ -6,8 +6,8 @@ public abstract partial class TmxReaderBase
   {
     var x = _reader.GetRequiredAttributeParseable<int>("x");
     var y = _reader.GetRequiredAttributeParseable<int>("y");
-    var width = _reader.GetRequiredAttributeParseable<uint>("width");
-    var height = _reader.GetRequiredAttributeParseable<uint>("height");
+    var width = _reader.GetRequiredAttributeParseable<int>("width");
+    var height = _reader.GetRequiredAttributeParseable<int>("height");
 
     var usesTileChildrenInsteadOfRawData = !encoding.HasValue;
     if (usesTileChildrenInsteadOfRawData)

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.Map.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.Map.cs
@@ -32,11 +32,11 @@ public abstract partial class TmxReaderBase
       _ => throw new InvalidOperationException($"Unknown render order '{s}'")
     }).GetValueOr(RenderOrder.RightDown);
     var compressionLevel = _reader.GetOptionalAttributeParseable<int>("compressionlevel").GetValueOr(-1);
-    var width = _reader.GetRequiredAttributeParseable<uint>("width");
-    var height = _reader.GetRequiredAttributeParseable<uint>("height");
-    var tileWidth = _reader.GetRequiredAttributeParseable<uint>("tilewidth");
-    var tileHeight = _reader.GetRequiredAttributeParseable<uint>("tileheight");
-    var hexSideLength = _reader.GetOptionalAttributeParseable<uint>("hexsidelength");
+    var width = _reader.GetRequiredAttributeParseable<int>("width");
+    var height = _reader.GetRequiredAttributeParseable<int>("height");
+    var tileWidth = _reader.GetRequiredAttributeParseable<int>("tilewidth");
+    var tileHeight = _reader.GetRequiredAttributeParseable<int>("tileheight");
+    var hexSideLength = _reader.GetOptionalAttributeParseable<int>("hexsidelength");
     var staggerAxis = _reader.GetOptionalAttributeEnum<StaggerAxis>("staggeraxis", s => s switch
     {
       "x" => StaggerAxis.X,

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
@@ -14,10 +14,10 @@ public abstract partial class TmxReaderBase
     var id = _reader.GetRequiredAttributeParseable<uint>("id");
     var name = _reader.GetOptionalAttribute("name").GetValueOr("");
     var @class = _reader.GetOptionalAttribute("class").GetValueOr("");
-    var x = _reader.GetOptionalAttributeParseable<uint>("x").GetValueOr(0);
-    var y = _reader.GetOptionalAttributeParseable<uint>("y").GetValueOr(0);
-    var width = _reader.GetOptionalAttributeParseable<uint>("width").GetValueOr(0);
-    var height = _reader.GetOptionalAttributeParseable<uint>("height").GetValueOr(0);
+    var x = _reader.GetOptionalAttributeParseable<int>("x").GetValueOr(0);
+    var y = _reader.GetOptionalAttributeParseable<int>("y").GetValueOr(0);
+    var width = _reader.GetOptionalAttributeParseable<int>("width").GetValueOr(0);
+    var height = _reader.GetOptionalAttributeParseable<int>("height").GetValueOr(0);
     var opacity = _reader.GetOptionalAttributeParseable<float>("opacity").GetValueOr(1.0f);
     var visible = _reader.GetOptionalAttributeParseable<uint>("visible").GetValueOr(1) == 1;
     var tintColor = _reader.GetOptionalAttributeClass<Color>("tintcolor");

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.TileLayer.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.TileLayer.cs
@@ -10,10 +10,10 @@ public abstract partial class TmxReaderBase
     var id = _reader.GetRequiredAttributeParseable<uint>("id");
     var name = _reader.GetOptionalAttribute("name").GetValueOr("");
     var @class = _reader.GetOptionalAttribute("class").GetValueOr("");
-    var x = _reader.GetOptionalAttributeParseable<uint>("x").GetValueOr(0);
-    var y = _reader.GetOptionalAttributeParseable<uint>("y").GetValueOr(0);
-    var width = _reader.GetRequiredAttributeParseable<uint>("width");
-    var height = _reader.GetRequiredAttributeParseable<uint>("height");
+    var x = _reader.GetOptionalAttributeParseable<int>("x").GetValueOr(0);
+    var y = _reader.GetOptionalAttributeParseable<int>("y").GetValueOr(0);
+    var width = _reader.GetRequiredAttributeParseable<int>("width");
+    var height = _reader.GetRequiredAttributeParseable<int>("height");
     var opacity = _reader.GetOptionalAttributeParseable<float>("opacity").GetValueOr(1.0f);
     var visible = _reader.GetOptionalAttributeParseable<uint>("visible").GetValueOr(1) == 1;
     var tintColor = _reader.GetOptionalAttributeClass<Color>("tintcolor");
@@ -59,8 +59,8 @@ public abstract partial class TmxReaderBase
     var id = _reader.GetRequiredAttributeParseable<uint>("id");
     var name = _reader.GetOptionalAttribute("name").GetValueOr("");
     var @class = _reader.GetOptionalAttribute("class").GetValueOr("");
-    var x = _reader.GetOptionalAttributeParseable<uint>("x").GetValueOr(0);
-    var y = _reader.GetOptionalAttributeParseable<uint>("y").GetValueOr(0);
+    var x = _reader.GetOptionalAttributeParseable<int>("x").GetValueOr(0);
+    var y = _reader.GetOptionalAttributeParseable<int>("y").GetValueOr(0);
     var opacity = _reader.GetOptionalAttributeParseable<float>("opacity").GetValueOr(1f);
     var visible = _reader.GetOptionalAttributeParseable<bool>("visible").GetValueOr(true);
     var tintColor = _reader.GetOptionalAttributeClass<Color>("tintcolor");

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.Tileset.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.Tileset.cs
@@ -31,12 +31,12 @@ public abstract partial class TmxReaderBase
     var tiledVersion = _reader.GetOptionalAttribute("tiledversion").GetValueOrOptional(parentTiledVersion);
     var name = _reader.GetRequiredAttribute("name");
     var @class = _reader.GetOptionalAttribute("class").GetValueOr("");
-    var tileWidth = _reader.GetRequiredAttributeParseable<uint>("tilewidth");
-    var tileHeight = _reader.GetRequiredAttributeParseable<uint>("tileheight");
-    var spacing = _reader.GetOptionalAttributeParseable<uint>("spacing").GetValueOr(0);
-    var margin = _reader.GetOptionalAttributeParseable<uint>("margin").GetValueOr(0);
-    var tileCount = _reader.GetRequiredAttributeParseable<uint>("tilecount");
-    var columns = _reader.GetRequiredAttributeParseable<uint>("columns");
+    var tileWidth = _reader.GetRequiredAttributeParseable<int>("tilewidth");
+    var tileHeight = _reader.GetRequiredAttributeParseable<int>("tileheight");
+    var spacing = _reader.GetOptionalAttributeParseable<int>("spacing").GetValueOr(0);
+    var margin = _reader.GetOptionalAttributeParseable<int>("margin").GetValueOr(0);
+    var tileCount = _reader.GetRequiredAttributeParseable<int>("tilecount");
+    var columns = _reader.GetRequiredAttributeParseable<int>("columns");
     var objectAlignment = _reader.GetOptionalAttributeEnum<ObjectAlignment>("objectalignment", s => s switch
     {
       "unspecified" => ObjectAlignment.Unspecified,
@@ -126,8 +126,8 @@ public abstract partial class TmxReaderBase
     });
     var source = _reader.GetOptionalAttribute("source");
     var transparentColor = _reader.GetOptionalAttributeClass<Color>("trans");
-    var width = _reader.GetOptionalAttributeParseable<uint>("width");
-    var height = _reader.GetOptionalAttributeParseable<uint>("height");
+    var width = _reader.GetOptionalAttributeParseable<int>("width");
+    var height = _reader.GetOptionalAttributeParseable<int>("height");
 
     _reader.ProcessChildren("image", (r, elementName) => elementName switch
     {
@@ -167,8 +167,8 @@ public abstract partial class TmxReaderBase
       "isometric" => GridOrientation.Isometric,
       _ => throw new InvalidOperationException($"Unknown orientation '{s}'")
     }).GetValueOr(GridOrientation.Orthogonal);
-    var width = _reader.GetRequiredAttributeParseable<uint>("width");
-    var height = _reader.GetRequiredAttributeParseable<uint>("height");
+    var width = _reader.GetRequiredAttributeParseable<int>("width");
+    var height = _reader.GetRequiredAttributeParseable<int>("height");
 
     _reader.ReadStartElement("grid");
     return new Grid { Orientation = orientation, Width = width, Height = height };
@@ -192,10 +192,10 @@ public abstract partial class TmxReaderBase
     var id = _reader.GetRequiredAttributeParseable<uint>("id");
     var type = _reader.GetOptionalAttribute("type").GetValueOr("");
     var probability = _reader.GetOptionalAttributeParseable<float>("probability").GetValueOr(0f);
-    var x = _reader.GetOptionalAttributeParseable<uint>("x").GetValueOr(0);
-    var y = _reader.GetOptionalAttributeParseable<uint>("y").GetValueOr(0);
-    var width = _reader.GetOptionalAttributeParseable<uint>("width");
-    var height = _reader.GetOptionalAttributeParseable<uint>("height");
+    var x = _reader.GetOptionalAttributeParseable<int>("x").GetValueOr(0);
+    var y = _reader.GetOptionalAttributeParseable<int>("y").GetValueOr(0);
+    var width = _reader.GetOptionalAttributeParseable<int>("width");
+    var height = _reader.GetOptionalAttributeParseable<int>("height");
 
     // Elements
     var propertiesCounter = 0;
@@ -212,7 +212,7 @@ public abstract partial class TmxReaderBase
       "animation" => () => Helpers.SetAtMostOnce(ref animation, r.ReadList<Frame>("animation", "frame", (ar) =>
       {
         var tileID = ar.GetRequiredAttributeParseable<uint>("tileid");
-        var duration = ar.GetRequiredAttributeParseable<uint>("duration");
+        var duration = ar.GetRequiredAttributeParseable<int>("duration");
         return new Frame { TileID = tileID, Duration = duration };
       }), "Animation"),
       _ => r.Skip

--- a/src/DotTiled/Tilesets/Frame.cs
+++ b/src/DotTiled/Tilesets/Frame.cs
@@ -13,5 +13,5 @@ public class Frame
   /// <summary>
   /// How long (in milliseconds) this frame should be displayed before advancing to the next frame.
   /// </summary>
-  public required uint Duration { get; set; }
+  public required int Duration { get; set; }
 }

--- a/src/DotTiled/Tilesets/Grid.cs
+++ b/src/DotTiled/Tilesets/Grid.cs
@@ -29,10 +29,10 @@ public class Grid
   /// <summary>
   /// Width of a grid cell.
   /// </summary>
-  public required uint Width { get; set; }
+  public required int Width { get; set; }
 
   /// <summary>
   /// Height of a grid cell.
   /// </summary>
-  public required uint Height { get; set; }
+  public required int Height { get; set; }
 }

--- a/src/DotTiled/Tilesets/Image.cs
+++ b/src/DotTiled/Tilesets/Image.cs
@@ -49,10 +49,10 @@ public class Image
   /// <summary>
   /// The image width in pixels, used for tile index correction when the image changes.
   /// </summary>
-  public Optional<uint> Width { get; set; } = Optional<uint>.Empty;
+  public Optional<int> Width { get; set; } = Optional<int>.Empty;
 
   /// <summary>
   /// The image height in pixels, used for tile index correction when the image changes.
   /// </summary>
-  public Optional<uint> Height { get; set; } = Optional<uint>.Empty;
+  public Optional<int> Height { get; set; } = Optional<int>.Empty;
 }

--- a/src/DotTiled/Tilesets/Tile.cs
+++ b/src/DotTiled/Tilesets/Tile.cs
@@ -26,22 +26,22 @@ public class Tile : HasPropertiesBase
   /// <summary>
   /// The X position of the sub-rectangle representing this tile within the tileset image.
   /// </summary>
-  public uint X { get; set; } = 0;
+  public int X { get; set; } = 0;
 
   /// <summary>
   /// The Y position of the sub-rectangle representing this tile within the tileset image.
   /// </summary>
-  public uint Y { get; set; } = 0;
+  public int Y { get; set; } = 0;
 
   /// <summary>
   /// The width of the sub-rectangle representing this tile within the tileset image.
   /// </summary>
-  public required uint Width { get; set; }
+  public required int Width { get; set; }
 
   /// <summary>
   /// The height of the sub-rectangle representing this tile within the tileset image.
   /// </summary>
-  public required uint Height { get; set; }
+  public required int Height { get; set; }
 
   /// <summary>
   /// Tile properties.

--- a/src/DotTiled/Tilesets/Tileset.cs
+++ b/src/DotTiled/Tilesets/Tileset.cs
@@ -128,32 +128,32 @@ public class Tileset : HasPropertiesBase
   /// <summary>
   /// The width of the tiles in this tileset, which should be at least 1 (non-zero) except in the case of image collection tilesets (in which case it stores the maximum tile width).
   /// </summary>
-  public required uint TileWidth { get; set; }
+  public required int TileWidth { get; set; }
 
   /// <summary>
   /// The height of the tiles in this tileset, which should be at least 1 (non-zero) except in the case of image collection tilesets (in which case it stores the maximum tile height).
   /// </summary>
-  public required uint TileHeight { get; set; }
+  public required int TileHeight { get; set; }
 
   /// <summary>
   /// The spacing in pixels between the tiles in this tileset (applies to the tileset image). Irrelevant for image collection tilesets.
   /// </summary>
-  public uint Spacing { get; set; } = 0;
+  public int Spacing { get; set; } = 0;
 
   /// <summary>
   /// The margin around the tiles in this tileset (applies to the tileset image). Irrelevant for image collection tilesets.
   /// </summary>
-  public uint Margin { get; set; } = 0;
+  public int Margin { get; set; } = 0;
 
   /// <summary>
   /// The number of tiles in this tileset.
   /// </summary>
-  public required uint TileCount { get; set; }
+  public required int TileCount { get; set; }
 
   /// <summary>
   /// The number of tile columns in the tileset.
   /// </summary>
-  public required uint Columns { get; set; }
+  public required int Columns { get; set; }
 
   /// <summary>
   /// Controls the aligntment for tile objects.


### PR DESCRIPTION
## Description
For the commonly used parts of the model API, it is more convenient if integer values are considered signed (since that is what the default in C# is). Parts of the model API that refer to identifiers, e.g. global tile IDs, local tile IDs, layer IDs etc. will all remain as unsigned integers.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).
