### PR TITLE
Parse new image size properties in ImageLayers in `tmj`

### DIFF
--- a/docs/docs/essentials/loading-maps.md
+++ b/docs/docs/essentials/loading-maps.md
@@ -5,12 +5,9 @@ Loading maps with DotTiled is very flexible and allows you as a developer to fre
 > [!TIP]
 > For a quick and easy way to load maps from the filesystem, please refer to the [quickstart guide](../quickstart.md).
 
-## File format caveats
+## File formats
 
 The <xref:DotTiled.Map> class is a representation of a Tiled map, mimicking the structure of a Tiled XML map file. Map files can either be in the [`.tmx`/XML](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/) or [`.tmj`/json](https://doc.mapeditor.org/en/stable/reference/json-map-format/) format. DotTiled supports **both** formats fully.
-
-> [!WARNING]
-> Using the `.tmj` file format will result in <xref:DotTiled.ImageLayer.Image> (the source image for image layers) not having the same amount of information as for the `.tmx` format. This is due to the fact that the `.tmj` format does not include the full information that the `.tmx` format does. This is not a problem with DotTiled, but rather a limitation of the `.tmj` format.
 
 ## The process of loading a map
 

--- a/docs/docs/essentials/representation-model.md
+++ b/docs/docs/essentials/representation-model.md
@@ -12,6 +12,9 @@ Certain properties throughout the representation model are marked as *optional* 
 
 The representation model is designed to be compatible with the latest version of Tiled. This means that it may not be able to read files from older versions of Tiled, or files that use features that are not yet supported by the representation model. However, here is a table of which versions of Tiled are supported by which versions of DotTiled.
 
-| Tiled version | Compatible DotTiled version(s) |
-|---------------|--------------------------------|
-| 1.11          | 0.1.0, 0.2.0, 0.2.1, 0.3.0     |
+You should use one of the versions of DotTiled that is compatible with the version of Tiled you are using.
+
+| Tiled version  | Compatible DotTiled version(s) |
+|----------------|--------------------------------|
+| 1.11.1, 1.11.2 | 0.4.0                          |
+| 1.11           | 0.1.0, 0.2.0, 0.2.1, 0.3.0     |

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
@@ -19,7 +19,7 @@ public partial class TestData
     CompressionLevel = -1,
     BackgroundColor = new TiledColor { R = 0, G = 0, B = 0, A = 0 },
     Version = "1.10",
-    TiledVersion = "1.11.0",
+    TiledVersion = "1.11.2",
     NextLayerID = 8,
     NextObjectID = 7,
     Tilesets = [
@@ -172,8 +172,8 @@ public partial class TestData
             {
               Format = ImageFormat.Png,
               Source = "tileset.png",
-              Width = fileExt == "tmx" ? 256 : 0, // Currently, json format does not
-              Height = fileExt == "tmx" ? 96 : 0  // include image dimensions in image layer https://github.com/mapeditor/tiled/issues/4028
+              Width = 256,
+              Height = 96
             },
             RepeatX = true
           },

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmj
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmj
@@ -114,6 +114,8 @@
                 {
                  "id":4,
                  "image":"tileset.png",
+                 "imageheight":96,
+                 "imagewidth":256,
                  "name":"ImageLayer",
                  "opacity":1,
                  "repeatx":true,
@@ -149,7 +151,7 @@
  "nextobjectid":7,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.11.0",
+ "tiledversion":"1.11.2",
  "tileheight":32,
  "tilesets":[
         {

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmx
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.0" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="8" nextobjectid="7">
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="8" nextobjectid="7">
  <tileset firstgid="1" source="tileset.tsx"/>
  <group id="2" name="Root">
   <objectgroup id="3" name="Objects">

--- a/src/DotTiled/DotTiled.csproj
+++ b/src/DotTiled/DotTiled.csproj
@@ -18,7 +18,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Copyright>Copyright © 2024 dcronqvist</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.ImageLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.ImageLayer.cs
@@ -19,6 +19,8 @@ public abstract partial class TmjReaderBase
     var properties = ResolveAndMergeProperties(@class, element.GetOptionalPropertyCustom("properties", ReadProperties).GetValueOr([]));
 
     var image = element.GetRequiredProperty<string>("image");
+    var imageWidth = element.GetOptionalProperty<int>("imagewidth").GetValueOr(0);
+    var imageHeight = element.GetOptionalProperty<int>("imageheight").GetValueOr(0);
     var repeatX = element.GetOptionalProperty<bool>("repeatx").GetValueOr(false);
     var repeatY = element.GetOptionalProperty<bool>("repeaty").GetValueOr(false);
     var transparentColor = element.GetOptionalPropertyParseable<TiledColor>("transparentcolor");
@@ -28,8 +30,8 @@ public abstract partial class TmjReaderBase
     var imgModel = new Image
     {
       Format = Helpers.ParseImageFormatFromSource(image),
-      Height = 0,
-      Width = 0,
+      Height = imageHeight,
+      Width = imageWidth,
       Source = image,
       TransparentColor = transparentColor
     };


### PR DESCRIPTION
## Description
As of [Tiled 1.11.1](https://doc.mapeditor.org/en/stable/reference/json-map-format/#tiled-1-11-1), image size properties are now present in Image layers when using the `.tmj` file format. DotTiled can now parse these values and provide them as available in its representation model. 

Bumped upcoming release version of DotTiled to 0.4.0 and included Tiled version 1.11.1 and 1.11.2 in representation model compatibility table for new version.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).
