### PR TITLE
Fix incorrect TextObject parsing

### DIFF
--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.cs
@@ -21,7 +21,7 @@ public partial class TestData
     Version = "1.10",
     TiledVersion = "1.11.2",
     NextLayerID = 8,
-    NextObjectID = 7,
+    NextObjectID = 8,
     Tilesets = [
       new Tileset
       {
@@ -104,6 +104,25 @@ public partial class TestData
                 Y = 110.333f,
                 Width = 64,
                 Height = 146
+              },
+              new TextObject
+              {
+                ID = 7,
+                Name = "Text1",
+                Rotation = 0,
+                Text = "Hello World!",
+                Visible = true,
+                Width = 116.869f,
+                Height = 19f,
+                X = 52.5197f,
+                Y = 4.0107f,
+                PixelSize = 18,
+                Wrap = true,
+                Bold = true,
+                Italic = true,
+                Underline = true,
+                Strikeout = true,
+                Kerning = false
               }
             ]
           },

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmj
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmj
@@ -62,6 +62,29 @@
                          "width":64,
                          "x":-35,
                          "y":110.333
+                        },
+                    
+                        {
+                         "height":19,
+                         "id":7,
+                         "name":"Text1",
+                         "rotation":0,
+                         "text":
+                            {
+                             "bold":true,
+                             "italic":true,
+                             "kerning":false,
+                             "pixelsize":18,
+                             "strikeout":true,
+                             "text":"Hello World!",
+                             "underline":true,
+                             "wrap":true
+                            },
+                         "type":"",
+                         "visible":true,
+                         "width":116.869277732794,
+                         "x":52.5197,
+                         "y":4.0107
                         }],
                  "opacity":1,
                  "type":"objectgroup",
@@ -148,7 +171,7 @@
          "y":0
         }],
  "nextlayerid":8,
- "nextobjectid":7,
+ "nextobjectid":8,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.11.2",

--- a/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmx
+++ b/src/DotTiled.Tests/TestData/Maps/map-with-many-layers/map-with-many-layers.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="8" nextobjectid="7">
+<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="8" nextobjectid="8">
  <tileset firstgid="1" source="tileset.tsx"/>
  <group id="2" name="Root">
   <objectgroup id="3" name="Objects">
@@ -12,6 +12,9 @@
    </object>
    <object id="5" template="poly.tx" x="20.6667" y="114.667"/>
    <object id="6" name="TileObj" gid="7" x="-35" y="110.333" width="64" height="146"/>
+   <object id="7" name="Text1" x="52.5197" y="4.0107" width="116.869" height="19">
+    <text pixelsize="18" wrap="1" bold="1" italic="1" underline="1" strikeout="1" kerning="0">Hello World!</text>
+   </object>
   </objectgroup>
   <group id="5" name="Sub">
    <layer id="7" name="Tile 3" width="5" height="5">

--- a/src/DotTiled.sln
+++ b/src/DotTiled.sln
@@ -19,8 +19,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DotTiled.Examples", "DotTil
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotTiled.Example.Raylib", "DotTiled.Examples\DotTiled.Example.Raylib\DotTiled.Example.Raylib.csproj", "{53585FB8-6E94-46F0-87E2-9692874E1714}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotTiled.Example.MonoGame", "DotTiled.Examples\DotTiled.Example.MonoGame\DotTiled.Example.MonoGame.csproj", "{F074756C-F84C-4F50-AE42-01017CD68AF7}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,15 +52,10 @@ Global
 		{53585FB8-6E94-46F0-87E2-9692874E1714}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{53585FB8-6E94-46F0-87E2-9692874E1714}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{53585FB8-6E94-46F0-87E2-9692874E1714}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F074756C-F84C-4F50-AE42-01017CD68AF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F074756C-F84C-4F50-AE42-01017CD68AF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F074756C-F84C-4F50-AE42-01017CD68AF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F074756C-F84C-4F50-AE42-01017CD68AF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F9892295-6C2C-4ABD-9D6F-2AC81D2C6E67} = {8C54542E-3C2C-486C-9BEF-4C510391AFDA}
 		{7541A9B3-43A5-45A7-939E-6F542319D990} = {8C54542E-3C2C-486C-9BEF-4C510391AFDA}
 		{53585FB8-6E94-46F0-87E2-9692874E1714} = {F3D6E648-AF8F-4EC9-A810-8C348DBB9924}
-		{F074756C-F84C-4F50-AE42-01017CD68AF7} = {F3D6E648-AF8F-4EC9-A810-8C348DBB9924}
 	EndGlobalSection
 EndGlobal

--- a/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmj/TmjReaderBase.ObjectLayer.cs
@@ -255,7 +255,7 @@ public abstract partial class TmjReaderBase
   internal static TextObject ReadText(JsonElement element)
   {
     var bold = element.GetOptionalProperty<bool>("bold").GetValueOr(false);
-    var color = element.GetOptionalPropertyParseable<TiledColor>("color").GetValueOr(TiledColor.Parse("#00000000", CultureInfo.InvariantCulture));
+    var color = element.GetOptionalPropertyParseable<TiledColor>("color").GetValueOr(TiledColor.Parse("#000000", CultureInfo.InvariantCulture));
     var fontfamily = element.GetOptionalProperty<string>("fontfamily").GetValueOr("sans-serif");
     var halign = element.GetOptionalPropertyParseable<TextHorizontalAlignment>("halign", s => s switch
     {

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
@@ -242,15 +242,15 @@ public abstract partial class TmxReaderBase
   internal TextObject ReadTextObject()
   {
     // Attributes
-    var fontFamily = _reader.GetOptionalAttribute("fontfamily") ?? "sans-serif";
-    var pixelSize = _reader.GetOptionalAttributeParseable<int>("pixelsize") ?? 16;
-    var wrap = _reader.GetOptionalAttributeParseable<bool>("wrap") ?? false;
-    var color = _reader.GetOptionalAttributeClass<TiledColor>("color") ?? TiledColor.Parse("#000000", CultureInfo.InvariantCulture);
-    var bold = _reader.GetOptionalAttributeParseable<bool>("bold") ?? false;
-    var italic = _reader.GetOptionalAttributeParseable<bool>("italic") ?? false;
-    var underline = _reader.GetOptionalAttributeParseable<bool>("underline") ?? false;
-    var strikeout = _reader.GetOptionalAttributeParseable<bool>("strikeout") ?? false;
-    var kerning = _reader.GetOptionalAttributeParseable<bool>("kerning") ?? true;
+    var fontFamily = _reader.GetOptionalAttribute("fontfamily").GetValueOr("sans-serif");
+    var pixelSize = _reader.GetOptionalAttributeParseable<int>("pixelsize").GetValueOr(16);
+    var wrap = _reader.GetOptionalAttributeParseable<int>("wrap").GetValueOr(0) == 1;
+    var color = _reader.GetOptionalAttributeClass<TiledColor>("color").GetValueOr(TiledColor.Parse("#000000", CultureInfo.InvariantCulture));
+    var bold = _reader.GetOptionalAttributeParseable<int>("bold").GetValueOr(0) == 1;
+    var italic = _reader.GetOptionalAttributeParseable<int>("italic").GetValueOr(0) == 1;
+    var underline = _reader.GetOptionalAttributeParseable<int>("underline").GetValueOr(0) == 1;
+    var strikeout = _reader.GetOptionalAttributeParseable<int>("strikeout").GetValueOr(0) == 1;
+    var kerning = _reader.GetOptionalAttributeParseable<int>("kerning").GetValueOr(1) == 1;
     var hAlign = _reader.GetOptionalAttributeEnum<TextHorizontalAlignment>("halign", s => s switch
     {
       "left" => TextHorizontalAlignment.Left,
@@ -258,14 +258,14 @@ public abstract partial class TmxReaderBase
       "right" => TextHorizontalAlignment.Right,
       "justify" => TextHorizontalAlignment.Justify,
       _ => throw new InvalidOperationException($"Unknown horizontal alignment '{s}'")
-    }) ?? TextHorizontalAlignment.Left;
+    }).GetValueOr(TextHorizontalAlignment.Left);
     var vAlign = _reader.GetOptionalAttributeEnum<TextVerticalAlignment>("valign", s => s switch
     {
       "top" => TextVerticalAlignment.Top,
       "center" => TextVerticalAlignment.Center,
       "bottom" => TextVerticalAlignment.Bottom,
       _ => throw new InvalidOperationException($"Unknown vertical alignment '{s}'")
-    }) ?? TextVerticalAlignment.Top;
+    }).GetValueOr(TextVerticalAlignment.Top);
 
     // Elements
     var text = _reader.ReadElementContentAsString("text", "");


### PR DESCRIPTION
## Description

Text objects were being incorrectly parsed, and this was not caught due to missing test maps with objects like that. This PR addresss it by adding such objects to a test map, and by fixing the incorrect parsing as well.

Had to remove the newly added MonoGame project from the solution as it caused a really slow build sometimes.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Tests have been added/updated to cover new functionality.
- [x] Documentation has been updated for all new changes (e.g., usage examples, API documentation).
