### PR TITLE
Enable AOT/Trim Compatibility

### DIFF
--- a/src/DotTiled/DotTiled.csproj
+++ b/src/DotTiled/DotTiled.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/DotTiled/Properties/CustomTypes/CustomClassDefinition.cs
+++ b/src/DotTiled/Properties/CustomTypes/CustomClassDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -104,6 +105,8 @@ public class CustomClassDefinition : HasPropertiesBase, ICustomTypeDefinition
   /// <param name="type">The type of the class to create a custom class definition from.</param>
   /// <returns>A new <see cref="CustomClassDefinition"/> instance.</returns>
   /// <exception cref="ArgumentException">Thrown when the specified type is not a class.</exception>
+  [RequiresUnreferencedCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
+  [RequiresDynamicCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
   public static CustomClassDefinition FromClass(Type type)
   {
     ArgumentNullException.ThrowIfNull(type, nameof(type));
@@ -127,6 +130,8 @@ public class CustomClassDefinition : HasPropertiesBase, ICustomTypeDefinition
   /// </summary>
   /// <typeparam name="T">The type of the class to create a custom class definition from.</typeparam>
   /// <returns>A new <see cref="CustomClassDefinition"/> instance.</returns>
+  [RequiresUnreferencedCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
+  [RequiresDynamicCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
   public static CustomClassDefinition FromClass<T>() where T : class, new() => FromClass(() => new T());
 
   /// <summary>
@@ -135,6 +140,8 @@ public class CustomClassDefinition : HasPropertiesBase, ICustomTypeDefinition
   /// <typeparam name="T">The type of the class to create a custom class definition from.</typeparam>
   /// <param name="factory">The factory function that creates an instance of the class.</param>
   /// <returns>A new <see cref="CustomClassDefinition"/> instance.</returns>
+  [RequiresUnreferencedCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
+  [RequiresDynamicCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
   public static CustomClassDefinition FromClass<T>(Func<T> factory) where T : class
   {
     var instance = factory();
@@ -149,6 +156,8 @@ public class CustomClassDefinition : HasPropertiesBase, ICustomTypeDefinition
     };
   }
 
+  [RequiresUnreferencedCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
+  [RequiresDynamicCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
   private static IProperty ConvertPropertyInfoToIProperty(object instance, PropertyInfo propertyInfo)
   {
     switch (propertyInfo.PropertyType)
@@ -183,6 +192,8 @@ public class CustomClassDefinition : HasPropertiesBase, ICustomTypeDefinition
     throw new NotSupportedException($"Type '{propertyInfo.PropertyType.Name}' is not supported in custom classes.");
   }
 
+  [RequiresUnreferencedCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
+  [RequiresDynamicCode("Use manually defined class properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#class-properties")]
   private static List<IProperty> GetNestedProperties(Type type, object instance)
   {
     var defaultInstance = Activator.CreateInstance(type);

--- a/src/DotTiled/Properties/CustomTypes/CustomEnumDefinition.cs
+++ b/src/DotTiled/Properties/CustomTypes/CustomEnumDefinition.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace DotTiled;
@@ -53,6 +54,8 @@ public class CustomEnumDefinition : ICustomTypeDefinition
   /// <typeparam name="T"></typeparam>
   /// <param name="storageType">The storage type of the custom enum. Defaults to <see cref="CustomEnumStorageType.String"/> to be consistent with Tiled.</param>
   /// <returns></returns>
+  [RequiresUnreferencedCode("Use manually defined enum properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#enum-properties")]
+  [RequiresDynamicCode("Use manually defined enum properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#enum-properties")]
   public static CustomEnumDefinition FromEnum<T>(CustomEnumStorageType storageType = CustomEnumStorageType.String) where T : Enum
   {
     var type = typeof(T);
@@ -73,6 +76,8 @@ public class CustomEnumDefinition : ICustomTypeDefinition
   /// <param name="type">The enum type to create a custom enum definition from.</param>
   /// <param name="storageType">The storage type of the custom enum. Defaults to <see cref="CustomEnumStorageType.String"/> to be consistent with Tiled.</param>
   /// <returns></returns>
+  [RequiresUnreferencedCode("Use manually defined enum properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#enum-properties")]
+  [RequiresDynamicCode("Use manually defined enum properties.", Url = "https://dcronqvist.github.io/DotTiled/docs/essentials/custom-properties.html#enum-properties")]
   public static CustomEnumDefinition FromEnum(Type type, CustomEnumStorageType storageType = CustomEnumStorageType.String)
   {
     if (!type.IsEnum)

--- a/src/DotTiled/Properties/IHasProperties.cs
+++ b/src/DotTiled/Properties/IHasProperties.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace DotTiled;
@@ -36,6 +37,7 @@ public interface IHasProperties
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <returns></returns>
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   T MapPropertiesTo<T>() where T : new();
 
   /// <summary>
@@ -44,7 +46,16 @@ public interface IHasProperties
   /// <typeparam name="T"></typeparam>
   /// <param name="initializer"></param>
   /// <returns></returns>
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   T MapPropertiesTo<T>(Func<T> initializer);
+
+  /// <summary>
+  /// Maps all properties in this object to a new instance of the specified type using the provided mapper.
+  /// </summary>
+  /// <typeparam name="T"></typeparam>
+  /// <param name="mapper"></param>
+  /// <returns></returns>
+  T MapPropertiesTo<T>(Func<IList<IProperty>, T> mapper);
 }
 
 /// <summary>
@@ -85,11 +96,17 @@ public abstract class HasPropertiesBase : IHasProperties
   }
 
   /// <inheritdoc/>
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   public T MapPropertiesTo<T>() where T : new() => CreateMappedInstance<T>(GetProperties());
 
   /// <inheritdoc/>
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   public T MapPropertiesTo<T>(Func<T> initializer) => CreateMappedInstance(GetProperties(), initializer);
 
+  /// <inheritdoc/>
+  public T MapPropertiesTo<T>(Func<IList<IProperty>, T> mapper) => mapper(GetProperties());
+
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   private static object CreatedMappedInstance(object instance, IList<IProperty> properties)
   {
     var type = instance.GetType();
@@ -141,8 +158,10 @@ public abstract class HasPropertiesBase : IHasProperties
     return instance;
   }
 
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   private static T CreateMappedInstance<T>(IList<IProperty> properties) where T : new() =>
     (T)CreatedMappedInstance(Activator.CreateInstance<T>() ?? throw new InvalidOperationException($"Failed to create instance of '{typeof(T).Name}'."), properties);
 
+  [RequiresUnreferencedCode("Use 'MapPropertiesTo' with a custom mapper instead.")]
   private static T CreateMappedInstance<T>(IList<IProperty> properties, Func<T> initializer) => (T)CreatedMappedInstance(initializer(), properties);
 }

--- a/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
+++ b/src/DotTiled/Serialization/Tmx/TmxReaderBase.ObjectLayer.cs
@@ -165,7 +165,17 @@ public abstract partial class TmxReaderBase
       return obj;
     }
 
-    return OverrideObject((dynamic)obj, (dynamic)foundObject);
+    return (obj, foundObject) switch
+    {
+      (TileObject tile, TileObject foundTile) => OverrideObject(tile, foundTile),
+      (RectangleObject rectangle, RectangleObject foundRectangle) => OverrideObject(rectangle, foundRectangle),
+      (PolygonObject polygon, PolygonObject foundPolygon) => OverrideObject(polygon, foundPolygon),
+      (PolylineObject polyline, PolylineObject foundPolyline) => OverrideObject(polyline, foundPolyline),
+      (EllipseObject ellipse, EllipseObject foundEllipse) => OverrideObject(ellipse, foundEllipse),
+      (TextObject text, TextObject foundText) => OverrideObject(text, foundText),
+      (PointObject point, PointObject foundPoint) => OverrideObject(point, foundPoint),
+      _ => obj
+    };
   }
 
   internal EllipseObject ReadEllipseObject()


### PR DESCRIPTION
This is a duplicate of #79, didn't notice that you had a dev branch and should have targeting that one. As for testing, I am not sure what can be done since really it just needs to compile without warnings since enabling the project settings will cause trim warnings to be thrown if it's not compatible.

The reason this is necessary is because certain things are just not allowed if you are using trimming or doing ahead-of-time compilation. Both of these would be needed if someone is wanting to use MonoGame and developing for a console.